### PR TITLE
feat: Add task and productivity analytics page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import Analytics from "./pages/Analytics";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -16,6 +17,7 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/analytics" element={<Analytics />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Clock, HelpCircle } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { Clock, HelpCircle, BarChartHorizontal } from 'lucide-react';
 import ThemeToggle from './ThemeToggle';
 
 interface HeaderProps {
@@ -34,6 +35,14 @@ const Header: React.FC<HeaderProps> = ({
         </button>
         
         <ThemeToggle />
+
+        <Link
+          to="/analytics"
+          className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-white/10 transition-colors"
+          aria-label="View analytics"
+        >
+          <BarChartHorizontal className="w-5 h-5 text-white/80" />
+        </Link>
         
         <button
           onClick={openHowToUse}

--- a/src/components/analytics/CompletedTasksLog.tsx
+++ b/src/components/analytics/CompletedTasksLog.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Task } from '@/hooks/useTasks';
+import { formatDistanceToNow } from 'date-fns';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { CheckCircle } from 'lucide-react';
+
+interface CompletedTasksLogProps {
+  tasks: Task[];
+}
+
+const CompletedTasksLog: React.FC<CompletedTasksLogProps> = ({ tasks }) => {
+  return (
+    <ScrollArea className="h-full">
+      <div className="space-y-4 pr-4">
+        {tasks.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full text-muted-foreground">
+            <p>No tasks completed yet.</p>
+            <p>Go crush some goals!</p>
+          </div>
+        ) : (
+          tasks.map(task => (
+            <div key={task.id} className="flex items-start space-x-3 p-3 bg-background rounded-md">
+              <CheckCircle className="w-5 h-5 text-green-500 mt-1 flex-shrink-0" />
+              <div className="flex-grow">
+                <p className="font-medium text-white">{task.title}</p>
+                {task.completedAt && (
+                  <p className="text-sm text-muted-foreground">
+                    Completed {formatDistanceToNow(new Date(task.completedAt), { addSuffix: true })}
+                  </p>
+                )}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </ScrollArea>
+  );
+};
+
+export default CompletedTasksLog;

--- a/src/components/analytics/DailyPomodoroChart.tsx
+++ b/src/components/analytics/DailyPomodoroChart.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { PomodoroSession } from '@/hooks/usePomodoroHistory';
+import { subDays, format, startOfDay } from 'date-fns';
+
+interface DailyPomodoroChartProps {
+  sessions: PomodoroSession[];
+}
+
+const DailyPomodoroChart: React.FC<DailyPomodoroChartProps> = ({ sessions }) => {
+  const processData = () => {
+    const last7Days = Array.from({ length: 7 }, (_, i) => startOfDay(subDays(new Date(), i))).reverse();
+
+    const data = last7Days.map(day => {
+      const dayStr = format(day, 'MMM d');
+      const count = sessions.filter(session => {
+        const sessionDay = startOfDay(new Date(session.completedAt));
+        return sessionDay.getTime() === day.getTime();
+      }).length;
+
+      return { name: dayStr, 'Focus Sessions': count };
+    });
+
+    return data;
+  };
+
+  const chartData = processData();
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart
+        data={chartData}
+        margin={{
+          top: 5,
+          right: 20,
+          left: -10,
+          bottom: 5,
+        }}
+      >
+        <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.2} />
+        <XAxis dataKey="name" />
+        <YAxis allowDecimals={false} />
+        <Tooltip
+          contentStyle={{
+            backgroundColor: '#1c1917',
+            borderColor: '#2c2a28',
+            color: '#d6d3d1'
+          }}
+        />
+        <Legend />
+        <Bar dataKey="Focus Sessions" fill="#8884d8" />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+};
+
+export default DailyPomodoroChart;

--- a/src/hooks/usePomodoroHistory.tsx
+++ b/src/hooks/usePomodoroHistory.tsx
@@ -1,0 +1,46 @@
+import { useState, useEffect } from 'react';
+
+export type PomodoroSession = {
+  id: string;
+  completedAt: number; // timestamp
+  duration: number; // in seconds
+  taskId?: string; // optional associated task
+};
+
+const usePomodoroHistory = () => {
+  const loadHistory = (): PomodoroSession[] => {
+    try {
+      const savedHistory = localStorage.getItem('pomodoroHistory');
+      return savedHistory ? JSON.parse(savedHistory) : [];
+    } catch (error) {
+      console.error('Error loading pomodoro history:', error);
+      return [];
+    }
+  };
+
+  const [history, setHistory] = useState<PomodoroSession[]>(loadHistory);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('pomodoroHistory', JSON.stringify(history));
+    } catch (error) {
+      console.error('Error saving pomodoro history:', error);
+    }
+  }, [history]);
+
+  const addPomodoroSession = (session: Omit<PomodoroSession, 'id' | 'completedAt'>) => {
+    const newSession: PomodoroSession = {
+      ...session,
+      id: Date.now().toString(),
+      completedAt: Date.now(),
+    };
+    setHistory(prev => [newSession, ...prev]);
+  };
+
+  return {
+    history,
+    addPomodoroSession,
+  };
+};
+
+export default usePomodoroHistory;

--- a/src/hooks/useTasks.tsx
+++ b/src/hooks/useTasks.tsx
@@ -9,6 +9,7 @@ export type Task = {
   estimatedPomodoros: number;
   completedPomodoros: number;
   createdAt: number;
+  completedAt?: number;
 };
 
 const useTasks = () => {
@@ -104,10 +105,18 @@ const useTasks = () => {
 
   // Toggle task completion
   const toggleTaskCompletion = (id: string) => {
-    setTasks(prev => 
-      prev.map(task => 
-        task.id === id ? { ...task, completed: !task.completed } : task
-      )
+    setTasks(prev =>
+      prev.map(task => {
+        if (task.id === id) {
+          const isCompleted = !task.completed;
+          return {
+            ...task,
+            completed: isCompleted,
+            completedAt: isCompleted ? Date.now() : undefined,
+          };
+        }
+        return task;
+      })
     );
   };
 
@@ -115,17 +124,29 @@ const useTasks = () => {
   const incrementTaskPomodoros = (id: string | null = activeTaskId) => {
     if (!id) return;
     
-    setTasks(prev => 
-      prev.map(task => 
-        task.id === id ? 
-          { 
-            ...task, 
-            completedPomodoros: task.completedPomodoros + 1,
-            // Auto-complete task if we've reached the estimated pomodoros
-            completed: task.completedPomodoros + 1 >= task.estimatedPomodoros ? true : task.completed
-          } : 
-          task
-      )
+    setTasks(prev =>
+      prev.map(task => {
+        if (task.id === id) {
+          const newCompletedPomodoros = task.completedPomodoros + 1;
+          const isCompleted = newCompletedPomodoros >= task.estimatedPomodoros;
+
+          if (isCompleted && !task.completed) {
+            // Task is being auto-completed
+            return {
+              ...task,
+              completedPomodoros: newCompletedPomodoros,
+              completed: true,
+              completedAt: Date.now(),
+            };
+          }
+
+          return {
+            ...task,
+            completedPomodoros: newCompletedPomodoros,
+          };
+        }
+        return task;
+      })
     );
   };
 

--- a/src/hooks/useTimer.tsx
+++ b/src/hooks/useTimer.tsx
@@ -25,7 +25,10 @@ const getTimerDurations = (isLongPomodoro: boolean): TimerDurations => {
   };
 };
 
-const useTimer = (isLongPomodoro: boolean = false) => {
+const useTimer = (
+  isLongPomodoro: boolean = false,
+  onPomodoroComplete: (duration: number) => void = () => {}
+) => {
   // Get appropriate timer durations based on the pomodoro preference
   const [timerDurations, setTimerDurations] = useState<TimerDurations>(getTimerDurations(isLongPomodoro));
   
@@ -190,6 +193,7 @@ const useTimer = (isLongPomodoro: boolean = false) => {
             
             // Switch to the next mode
             if (prev.mode === 'pomodoro') {
+              onPomodoroComplete(timerDurations.pomodoro);
               completedPomos += 1;
               
               // After 4 pomodoros, take a long break
@@ -250,7 +254,7 @@ const useTimer = (isLongPomodoro: boolean = false) => {
         intervalRef.current = null;
       }
     };
-  }, [timerState.isRunning, timerDurations]);
+  }, [timerState.isRunning, timerDurations, onPomodoroComplete]);
 
   // Switch timer mode
   const switchMode = (mode: TimerMode) => {

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft } from 'lucide-react';
+import usePomodoroHistory from '@/hooks/usePomodoroHistory';
+import useTasks from '@/hooks/useTasks';
+import DailyPomodoroChart from '@/components/analytics/DailyPomodoroChart';
+import CompletedTasksLog from '@/components/analytics/CompletedTasksLog';
+
+const Analytics = () => {
+  const { history: pomodoroHistory } = usePomodoroHistory();
+  const { tasks } = useTasks();
+
+  const completedTasks = tasks.filter(task => task.completed).sort((a, b) => (b.completedAt || 0) - (a.completedAt || 0));
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-6 text-white">
+      <div className="absolute inset-0 -z-10 h-full w-full bg-background bg-[linear-gradient(to_right,#8080800a_1px,transparent_1px),linear-gradient(to_bottom,#8080800a_1px,transparent_1px)] bg-[size:14px_24px]"></div>
+      <header className="flex items-center justify-between mb-8">
+        <h1 className="text-3xl font-bold">Productivity Analytics</h1>
+        <Button asChild variant="outline">
+          <Link to="/">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to Timer
+          </Link>
+        </Button>
+      </header>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <div className="p-6 bg-card rounded-lg border h-[400px] flex flex-col">
+          <h2 className="text-xl font-semibold mb-4">Focus Sessions (Last 7 Days)</h2>
+          <div className="flex-grow">
+            <DailyPomodoroChart sessions={pomodoroHistory} />
+          </div>
+        </div>
+
+        <div className="p-6 bg-card rounded-lg border h-[400px] flex flex-col">
+          <h2 className="text-xl font-semibold mb-4">Completed Tasks Log</h2>
+          <div className="flex-grow">
+            <CompletedTasksLog tasks={completedTasks} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Analytics;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -12,6 +12,7 @@ import DonationButton from '@/components/DonationButton';
 import BackgroundRenderer from '@/components/BackgroundRenderer';
 import useTimer from '@/hooks/useTimer';
 import useTasks from '@/hooks/useTasks';
+import usePomodoroHistory from '@/hooks/usePomodoroHistory';
 import { useTheme } from '@/hooks/useTheme';
 import { Heart } from 'lucide-react';
 import { Toaster } from '@/components/ui/toaster';
@@ -30,17 +31,7 @@ const Index = () => {
   const [isFullscreen, setIsFullscreen] = useState(false);
   
   const { theme, setTheme } = useTheme();
-  
-  const {
-    timerState,
-    timerDurations,
-    switchMode,
-    startTimer,
-    pauseTimer,
-    resetTimer,
-    formatTime
-  } = useTimer(isLongPomodoro);
-  
+
   const {
     tasks,
     activeTaskId,
@@ -52,6 +43,24 @@ const Index = () => {
     setActiveTask,
     clearCompletedTasks
   } = useTasks();
+  const { addPomodoroSession } = usePomodoroHistory();
+
+  function handlePomodoroComplete(duration: number) {
+    if (activeTaskId) {
+      incrementTaskPomodoros(activeTaskId);
+    }
+    addPomodoroSession({ duration, taskId: activeTaskId || undefined });
+  }
+
+  const {
+    timerState,
+    timerDurations,
+    switchMode,
+    startTimer,
+    pauseTimer,
+    resetTimer,
+    formatTime
+  } = useTimer(isLongPomodoro, handlePomodoroComplete);
 
   // Set dark mode by default
   useEffect(() => {


### PR DESCRIPTION
This commit introduces a new analytics feature that provides users with insights into their work habits.

The new `/analytics` page includes:
- A bar chart showing the number of completed Pomodoro focus sessions over the last 7 days.
- A log of all completed tasks, including when they were completed.

To support this, the following changes were made:
- A `usePomodoroHistory` hook was created to store a history of completed Pomodoro sessions in `localStorage`.
- The `useTasks` hook was updated to add a `completedAt` timestamp to tasks when they are marked as complete.
- The `useTimer` hook now invokes a callback on Pomodoro completion to log the session and associate it with the active task.